### PR TITLE
add getaddrinfo to raw_sock

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: "*,\
 -cppcoreguidelines-pro-type-vararg,\
 -cppcoreguidelines-special-member-functions,\
 -fuchsia-default-arguments-calls,\
+-fuchsia-multiple-inheritance,\
 -fuchsia-statically-constructed-objects,\
 -google-build-using-namespace,\
 -google-readability-braces-around-statements,\

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,6 @@ Checks: "*,\
 -cppcoreguidelines-pro-type-vararg,\
 -cppcoreguidelines-special-member-functions,\
 -fuchsia-default-arguments-calls,\
--fuchsia-multiple-inheritance,\
 -fuchsia-statically-constructed-objects,\
 -google-build-using-namespace,\
 -google-readability-braces-around-statements,\

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ endif()
 
 add_library(ttls
   src/dispatcher.cc
-  src/libc_socket.cc
   src/mbedtls_socket.cc
   src/test_server.cc
   3rdparty/mbedtls/ssl_server.c)
@@ -43,6 +42,7 @@ target_include_directories(ttls
 
 if(NOT TTLS_NOTEST)
   add_executable(ttls_test
+    src/libc_socket.cc
     src/dispatcher_test.cc
     src/mbedtls_test.cc
     src/util.cc)

--- a/include/ttls/dispatcher.h
+++ b/include/ttls/dispatcher.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <netdb.h>
+
 #include <memory>
 #include <mutex>
 #include <nlohmann/json_fwd.hpp>
@@ -7,6 +9,7 @@
 #include <unordered_set>
 
 #include "mbedtls_socket.h"
+#include "raw_socket.h"
 #include "socket.h"
 
 namespace edgeless::ttls {
@@ -20,7 +23,7 @@ class Dispatcher final {
    * @param raw Socket functions that will be used if connection should not be wrapped.
    * @param tls Socket functions that will be used if connection should be wrapped.
    */
-  Dispatcher(std::string_view config, const SocketPtr& raw, const MbedtlsSockPtr& tls);
+  Dispatcher(std::string_view config, const RawSockPtr& raw, const MbedtlsSockPtr& tls);
 
   ~Dispatcher();
 
@@ -30,15 +33,17 @@ class Dispatcher final {
   ssize_t Recv(int sockfd, void* buf, size_t len, int flags);
   ssize_t Send(int sockfd, const void* buf, size_t len, int flags);
   int Shutdown(int sockfd, int how);
+  int Getaddrinfo(const char* node, const char* service, const addrinfo* hints, addrinfo** res);
 
  private:
   const nlohmann::json& Conf() const noexcept;
   bool IsTls(int sockfd);
   std::mutex mtx_;
 
+  std::unordered_map<std::string, std::string> ip_domain_;
   std::unordered_set<int> tls_fds_;
   std::unique_ptr<nlohmann::json> config_;
-  SocketPtr raw_;
+  RawSockPtr raw_;
   MbedtlsSockPtr tls_;
 };
 

--- a/include/ttls/dispatcher.h
+++ b/include/ttls/dispatcher.h
@@ -38,7 +38,8 @@ class Dispatcher final {
  private:
   const nlohmann::json& Conf() const noexcept;
   bool IsTls(int sockfd);
-  std::mutex mtx_;
+  std::mutex fds_mtx_;
+  std::mutex domain_mtx_;
 
   std::unordered_map<std::string, std::string> ip_domain_;
   std::unordered_set<int> tls_fds_;

--- a/include/ttls/libc_socket.h
+++ b/include/ttls/libc_socket.h
@@ -1,16 +1,17 @@
 #pragma once
 
-#include "socket.h"
+#include "raw_socket.h"
 
 namespace edgeless::ttls {
 
-class LibcSocket : public Socket {
+class LibcSocket : public RawSocket {
  public:
   int Close(int fd) override;
   int Connect(int sockfd, const sockaddr* addr, socklen_t addrlen) override;
   ssize_t Recv(int sockfd, void* buf, size_t len, int flags) override;
   ssize_t Send(int sockfd, const void* buf, size_t len, int flags) override;
   int Shutdown(int sockfd, int how) override;
+  int Getaddrinfo(const char* node, const char* service, const addrinfo* hints, addrinfo** res) override;
 };
 
 }  // namespace edgeless::ttls

--- a/include/ttls/raw_socket.h
+++ b/include/ttls/raw_socket.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <netdb.h>
+
+#include "socket.h"
+
+namespace edgeless::ttls {
+
+class RawSocket : public Socket {
+ public:
+  virtual int Getaddrinfo(const char* node, const char* service, const addrinfo* hints, addrinfo** res) = 0;
+};
+
+typedef std::shared_ptr<RawSocket> RawSockPtr;
+
+}  // namespace edgeless::ttls

--- a/include/ttls/ttls.h
+++ b/include/ttls/ttls.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "dispatcher.h"
-#include "libc_socket.h"
 #include "mbedtls_socket.h"
+#include "raw_socket.h"
 #include "socket.h"
 #include "test_server.h"

--- a/src/dispatcher.cc
+++ b/src/dispatcher.cc
@@ -15,7 +15,7 @@ using namespace edgeless::ttls;
 using namespace std::string_literals;
 
 bool Dispatcher::IsTls(int sockfd) {
-  const std::lock_guard<std::mutex> lock(mtx_);
+  const std::lock_guard<std::mutex> lock(fds_mtx_);
   return tls_fds_.find(sockfd) != tls_fds_.cend();
 }
 
@@ -44,12 +44,16 @@ int Dispatcher::Connect(int sockfd, const sockaddr* addr, socklen_t addrlen) {
     return -1;
   }
 
-  ip_buf = ip_buf.substr(0, ip_buf.find('\0'));
-  port_buf = port_buf.substr(0, port_buf.find('\0'));
+  ip_buf.erase(ip_buf.find('\0'));
+  port_buf.erase(port_buf.find('\0'));
   std::string domain_port = ip_buf + ":" + port_buf;
   // prefer domains over IPs
-  if (ip_domain_.find(ip_buf) != ip_domain_.cend())
-    domain_port = ip_domain_.at(ip_buf) + ":" + port_buf;
+  {
+    const std::lock_guard<std::mutex> lock(domain_mtx_);
+    const auto it = ip_domain_.find(ip_buf);
+    if (it != ip_domain_.cend())
+      domain_port = it->second + ":" + port_buf;
+  }
 
   // 2. check if not in json --> raw_->Connect(...)
   if (Conf()["tls"].find(domain_port) == Conf()["tls"].cend())
@@ -58,7 +62,7 @@ int Dispatcher::Connect(int sockfd, const sockaddr* addr, socklen_t addrlen) {
   // 3. else --> save fd + tls_->Connect(...)
   try {
     {
-      std::lock_guard<std::mutex> lock(mtx_);
+      std::lock_guard<std::mutex> lock(fds_mtx_);
       tls_fds_.insert(sockfd);
     }
     return tls_->Connect(sockfd, addr, addrlen, Conf()["tls"][domain_port]);
@@ -109,7 +113,7 @@ int Dispatcher::Close(int sockfd) {
   try {
     tls_->Close(sockfd);
     {
-      std::lock_guard<std::mutex> lock(mtx_);
+      std::lock_guard<std::mutex> lock(fds_mtx_);
       tls_fds_.erase(sockfd);
     }
     return 0;
@@ -122,31 +126,35 @@ int Dispatcher::Getaddrinfo(const char* node, const char* service, const addrinf
   // TODO: Check if service/port is ever used
   // [pid 108970] client->getaddrinfo("google.de", nil, 0xc00009c090, 0xc0000a4010)                       = 0
 
-  for (auto& el : Conf()["tls"].items()) {
-    std::string domain = el.key().substr(0, el.key().find(':'));
+  int ret = raw_->Getaddrinfo(node, service, hints, res);
+  if (ret != 0) {
+    return ret;
+  }
 
-    if (std::string(node) == domain) {
+  for (const auto& el : Conf()["tls"].items()) {
+    const std::string domain = el.key().substr(0, el.key().find(':'));
+
+    if (node == domain) {
       // get all IPs
-      int ret = raw_->Getaddrinfo(node, service, hints, res);
-      if (ret != 0) {
-        return ret;
-      }
+
       // save all (IPs, domain) in ip_domain_
-      addrinfo* rp = nullptr;
-      for (rp = *res; rp != nullptr; rp = rp->ai_next) {
+      for (const addrinfo* rp = *res; rp != nullptr; rp = rp->ai_next) {
         //parse ip out of sockaddr
         std::string ip_buf(NI_MAXHOST, ' ');
         ret = getnameinfo(rp->ai_addr, rp->ai_addrlen, ip_buf.data(), NI_MAXHOST, nullptr, 0, NI_NUMERICHOST);
-        ip_buf = ip_buf.substr(0, ip_buf.find('\0'));
         if (ret != 0) {
           return -1;
         }
-        ip_domain_.try_emplace(ip_buf, domain);
+        ip_buf.erase(ip_buf.find('\0'));
+        {
+          const std::lock_guard<std::mutex> lock(domain_mtx_);
+          ip_domain_.try_emplace(std::move(ip_buf), domain);
+        }
       }
       return 0;
     }
   }
-  return raw_->Getaddrinfo(node, service, hints, res);
+  return 0;
 }
 
 const nlohmann::json& Dispatcher::Conf() const noexcept {

--- a/src/libc_socket.cc
+++ b/src/libc_socket.cc
@@ -18,3 +18,6 @@ ssize_t LibcSocket::Send(int sockfd, const void* buf, size_t len, int /*flags*/)
 int LibcSocket::Shutdown(int sockfd, int how) {
   return shutdown(sockfd, how);
 }
+int LibcSocket::Getaddrinfo(const char* node, const char* service, const addrinfo* hints, addrinfo** res) {
+  return getaddrinfo(node, service, hints, res);
+}

--- a/src/mock_socket.h
+++ b/src/mock_socket.h
@@ -63,17 +63,21 @@ struct MockSocket : MbedtlsSocket, RawSocket {
     return len;
   }
 
+  sockaddr getaddrinfo_addr{};
+  addrinfo getaddrinfo_addrinfo{};
+
   int Getaddrinfo(const char* node, const char* /*service*/, const addrinfo* /*hints*/, addrinfo** res) override {
-    sockaddr addr{};
-    if (std::string(node) == "service.name") {
-      addr = MakeSockaddr("133.133.133.133", 0);
+    if (std::string_view(node) == "service.name") {
+      getaddrinfo_addr = MakeSockaddr("133.133.133.133", 0);
+    } else if (std::string_view(node) == "other.service.name") {
+      getaddrinfo_addr = MakeSockaddr("200.200.200.200", 0);
+    } else {
+      return -1;
     }
-    if (std::string(node) == "other.service.name") {
-      addr = MakeSockaddr("200.200.200.200", 0);
-    }
-    *res = new addrinfo{};
-    (*res)->ai_addr = new sockaddr(addr);
-    res[0]->ai_addrlen = sizeof(sockaddr);
+    getaddrinfo_addrinfo = {};
+    getaddrinfo_addrinfo.ai_addr = &getaddrinfo_addr;
+    getaddrinfo_addrinfo.ai_addrlen = sizeof(getaddrinfo_addr);
+    *res = &getaddrinfo_addrinfo;
     return 0;
   }
 };


### PR DESCRIPTION
Some explanation: 
raw_socket is now only an interface which needs to be implemented by the program itself. This is because we need to hook the libc call to getaddrinfo while using the call itself on the raw_socket itself. So we need to make sure that we don't loop indefinitely.

For testing purposes we implement libc_socket which is used in mbedtls_test. Since we cannot provide any default implementation of raw_socket, libc_socket is only compiled when the tests are compiled. 

Additionally, one needs to mention that we still support IPs in the ttls config, but prefer domain names. 
When the client connects to an IP, we check if the client requested a domain which matches the IP. If so, we search for the domain in the ttls config. If the domain was not translated to by getaddrinfo, we search for the IP in the ttls conf.