### PR TITLE
Feat/accept wildcard

### DIFF
--- a/src/dispatcher.cc
+++ b/src/dispatcher.cc
@@ -165,7 +165,7 @@ int Dispatcher::Getaddrinfo(const char* node, const char* service, const addrinf
 
 int Dispatcher::Accept4(int sockfd, sockaddr* addr, socklen_t* addrlen, int flags) {
   sockaddr sock_addr{};
-  socklen_t sock_len{};
+  socklen_t sock_len = sizeof(sockaddr);
 
   const int fd = raw_->Accept4(sockfd, &sock_addr, &sock_len, flags);
 


### PR DESCRIPTION
especially useful when the remote client port is unknown e.g. when ttls is used as a standalone lib. Moreover, this will be used in the ERT server-side test as we can't easily set the client port in our test_client.

As mentioned in https://github.com/edgelesssys/emojivoto/pull/11#issuecomment-790501876 wildcards are a general feature. This PR is supposed to be a first attempt, as a better approach to domain name handling and preference in the selection of config entries will most likely be needed in the following emojivoto integration.