### PR TITLE
Feat/server side bind

### DIFF
--- a/include/ttls/dispatcher.h
+++ b/include/ttls/dispatcher.h
@@ -30,6 +30,7 @@ class Dispatcher final {
   // socket functions
   int Close(int fd);
   int Connect(int sockfd, const sockaddr* addr, socklen_t addrlen);
+  int Bind(int sockfd, const sockaddr* addr, socklen_t addrlen);
   int Accept4(int sockfd, sockaddr* addr, socklen_t* addrlen, int flags);
   ssize_t Recv(int sockfd, void* buf, size_t len, int flags);
   ssize_t Send(int sockfd, const void* buf, size_t len, int flags);
@@ -39,11 +40,18 @@ class Dispatcher final {
  private:
   const nlohmann::json& Conf() const noexcept;
   bool IsTls(int sockfd);
-  std::mutex fds_mtx_;
-  std::mutex domain_mtx_;
+
+  //TODO: Refacor to combine mtx and data structure
+
+  std::mutex tls_fds_mtx_;
+  std::mutex ip_domain_mtx_;
+  std::mutex fd_entry_mtx_;
 
   std::unordered_map<std::string, std::string> ip_domain_;
+  // contains connected and accepted sockfds
   std::unordered_set<int> tls_fds_;
+  // map bound fds to their entryname in the json
+  std::unordered_map<int, std::string> fd_entry_;
   std::unique_ptr<nlohmann::json> config_;
   RawSockPtr raw_;
   MbedtlsSockPtr tls_;

--- a/include/ttls/libc_socket.h
+++ b/include/ttls/libc_socket.h
@@ -8,6 +8,7 @@ class LibcSocket : public RawSocket {
  public:
   int Close(int fd) override;
   int Connect(int sockfd, const sockaddr* addr, socklen_t addrlen) override;
+  int Bind(int sockfd, const sockaddr* addr, socklen_t addrlen) override;
   int Accept4(int sockfd, sockaddr* addr, socklen_t* addrlen, int flags) override;
   ssize_t Recv(int sockfd, void* buf, size_t len, int flags) override;
   ssize_t Send(int sockfd, const void* buf, size_t len, int flags) override;

--- a/include/ttls/mbedtls_socket.h
+++ b/include/ttls/mbedtls_socket.h
@@ -20,7 +20,9 @@ class MbedtlsSocket : public Socket {
   int Close(int sockfd) override;
   int Connect(int sockfd, const sockaddr* addr, socklen_t addrlen) override;
   int Accept4(int sockfd, sockaddr* addr, socklen_t* addrlen, int flags) override;
-  virtual int Accept(int sockfd, const std::string& ca_crt,
+
+  // accepts a new connection from sockfd and establishes a tls connection on the returned fd
+  virtual int Accept(int sockfd, sockaddr* addr, socklen_t* addrlen, int flags, const std::string& ca_crt,
                      const std::string& sever_crt, const std::string& sever_key);
   virtual int Connect(int sockfd, const sockaddr* addr, socklen_t addrlen, const std::string& hostname,
                       const std::string& ca_crt, const std::string& client_crt, const std::string& client_key);

--- a/include/ttls/raw_socket.h
+++ b/include/ttls/raw_socket.h
@@ -9,6 +9,7 @@ namespace edgeless::ttls {
 class RawSocket : public Socket {
  public:
   virtual int Getaddrinfo(const char* node, const char* service, const addrinfo* hints, addrinfo** res) = 0;
+  virtual int Bind(int sockfd, const sockaddr* addr, socklen_t addrlen) = 0;
 };
 
 typedef std::shared_ptr<RawSocket> RawSockPtr;

--- a/poc/client-side/client/main.cc
+++ b/poc/client-side/client/main.cc
@@ -22,6 +22,9 @@ class Sock final : public edgeless::ttls::RawSocket {
   int Accept4(int /*sockfd*/, sockaddr* /*addr*/, socklen_t* /*addrlen*/, int /*flags*/) override {
     return -1;
   }
+  int Bind(int /*sockfd*/, const sockaddr* /*addr*/, socklen_t /*addrlen*/) override {
+    return -1;
+  }
   ssize_t Send(int sockfd, const void* buf, size_t len, int /*flags*/)
       override {
     return write(sockfd, buf, len);

--- a/poc/server-side/client/client.go
+++ b/poc/server-side/client/client.go
@@ -5,9 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
-	"time"
 )
 
 func main() {
@@ -26,18 +24,7 @@ func main() {
 	}
 	conf := &tls.Config{Certificates: []tls.Certificate{cert}, ClientCAs: caCertPool, RootCAs: caCertPool, ClientAuth: tls.RequireAndVerifyClientCert}
 
-	localTCPAddr, err := net.ResolveTCPAddr("tcp", ":9090")
-	if err != nil {
-		panic(err)
-	}
-	//conf.BuildNameToCertificate()
-	transport := &http.Transport{TLSClientConfig: conf, DialContext: (&net.Dialer{
-		LocalAddr: localTCPAddr,
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-		DualStack: true,
-	}).DialContext,
-	}
+	transport := &http.Transport{TLSClientConfig: conf}
 	client := &http.Client{Transport: transport}
 
 	resp, err := client.Get("https://localhost:9000")

--- a/src/libc_socket.cc
+++ b/src/libc_socket.cc
@@ -9,6 +9,9 @@ int LibcSocket::Close(int fd) {
 int LibcSocket::Connect(int sockfd, const sockaddr* addr, socklen_t addrlen) {
   return connect(sockfd, addr, addrlen);
 }
+int LibcSocket::Bind(int sockfd, const sockaddr* addr, socklen_t addrlen) {
+  return bind(sockfd, addr, addrlen);
+}
 int LibcSocket::Accept4(int sockfd, sockaddr* addr, socklen_t* addrlen, int flags) {
   return accept4(sockfd, addr, addrlen, flags);
 }

--- a/src/mbedtls_test.cc
+++ b/src/mbedtls_test.cc
@@ -126,10 +126,10 @@ TEST(Mbedtls, ServerSendAndRecieveNonBlock) {
   socklen_t len = sizeof(sockaddr);
   int client_fd = -1;
   do {
-    client_fd = libc_sock->Accept4(fd, &client_sock, &len, 0);
+    client_fd = sock.Accept(fd, &client_sock, &len, 0, CA_CRT, SERVER_CRT, SERVER_KEY);
   } while (client_fd == -1 && errno == EAGAIN);
 
-  EXPECT_EQ(sock.Accept(client_fd, CA_CRT, SERVER_CRT, SERVER_KEY), 0);
+  EXPECT_GT(client_fd, 0);
 
   std::string buf(4096, ' ');
   int ret = -1;


### PR DESCRIPTION
Some remarks:
I removed one testcase since we don't deref the pointers in the Dispatcher::Accpet4 anymore. The *sockaddr as well as *addrlen should directly be passed into the syscall and should never be read. 

A Go HTTP Server uses the following bind syscall:
```
bind(3, {sa_family=AF_INET6, sin6_port=htons(9000), inet_pton(AF_INET6, "::", &sin6_addr), sin6_flowinfo=htonl(0), sin6_scope_id=0}, 28)
```

Since it uses "::" as addr an 9000 as a port, we expect any entry in tls -> Incoming to use "*" as addr (e.g. "*:9000").