### PR TITLE
Feat/errno

### DIFF
--- a/include/ttls/mbedtls_socket.h
+++ b/include/ttls/mbedtls_socket.h
@@ -23,7 +23,7 @@ class MbedtlsSocket : public Socket {
 
   // accepts a new connection from sockfd and establishes a tls connection on the returned fd
   virtual int Accept(int sockfd, sockaddr* addr, socklen_t* addrlen, int flags, const std::string& ca_crt,
-                     const std::string& sever_crt, const std::string& sever_key);
+                     const std::string& sever_crt, const std::string& sever_key, bool client_auth);
   virtual int Connect(int sockfd, const sockaddr* addr, socklen_t addrlen, const std::string& hostname,
                       const std::string& ca_crt, const std::string& client_crt, const std::string& client_key);
   ssize_t Recv(int sockfd, void* buf, size_t len, int flags) override;

--- a/src/dispatcher.cc
+++ b/src/dispatcher.cc
@@ -198,7 +198,7 @@ int Dispatcher::Accept4(int sockfd, sockaddr* addr, socklen_t* addrlen, int flag
   try {
     const auto& conf = Conf()["tls"]["Incoming"][entry_name];
     const int client_fd = tls_->Accept(sockfd, addr, addrlen, flags, conf["cacrt"],
-                                       conf["clicert"], conf["clikey"]);
+                                       conf["clicert"], conf["clikey"], conf["clientAuth"]);
     {
       std::lock_guard<std::mutex> lock(tls_fds_mtx_);
       tls_fds_.insert(client_fd);

--- a/src/dispatcher_test.cc
+++ b/src/dispatcher_test.cc
@@ -52,7 +52,7 @@ TEST(Dispatcher, ClientForwardConfig) {
   const auto tls = std::make_shared<MockSocket>();
   const int tls_fd = 4;
 
-  Dispatcher dispatcher(R"({"tls":{"Outgoing":{"127.0.0.1:443":{"cacrt": "CA_CRT", "clicert": "", "clikey": ""},"192.168.0.1:80": {"cacrt" : "DIFF_CA_CRT", "clicert": "", "clikey": ""}}, "Incoming" : {"111.111.111.111:22": { "cacrt": "CA_CRT", "clicert": "SERVER_CRT", "clikey": "" }}}})",
+  Dispatcher dispatcher(R"({"tls":{"Outgoing":{"127.0.0.1:443":{"cacrt": "CA_CRT", "clicert": "", "clikey": ""},"192.168.0.1:80": {"cacrt" : "DIFF_CA_CRT", "clicert": "", "clikey": ""}}, "Incoming" : {"111.111.111.111:22": { "cacrt": "CA_CRT", "clicert": "SERVER_CRT", "clikey": "", "clientAuth": true }}}})",
                         raw, tls);
 
   sockaddr sock_addr = MakeSockaddr("127.0.0.1", 443);
@@ -139,7 +139,7 @@ TEST(Dispatcher, ServerForwardConfig) {
   const int bind_fd = 3;
   const int tls_fd = 4;
 
-  Dispatcher dispatcher(R"({"tls":{"Outgoing":{"127.0.0.1:443":{"cacrt": "CA_CRT", "clicert": "", "clikey": ""},"192.168.0.1:80": {"cacrt" : "DIFF_CA_CRT", "clicert": "", "clikey": ""}}, "Incoming" : {"*:9000": { "cacrt": "CA_CRT", "clicert": "SERVER_CRT", "clikey": "SERVER_KEY" }}}})",
+  Dispatcher dispatcher(R"({"tls":{"Outgoing":{"127.0.0.1:443":{"cacrt": "CA_CRT", "clicert": "", "clikey": ""},"192.168.0.1:80": {"cacrt" : "DIFF_CA_CRT", "clicert": "", "clikey": ""}}, "Incoming" : {"*:9000": { "cacrt": "CA_CRT", "clicert": "SERVER_CRT", "clikey": "SERVER_KEY", "clientAuth": true }}}})",
                         raw, tls);
 
   auto bind_addr = MakeSockaddr("127.0.0.1", 9000);

--- a/src/mbedtls_socket.cc
+++ b/src/mbedtls_socket.cc
@@ -214,7 +214,7 @@ int MbedtlsSocket::Accept4(int /*sockfd*/, sockaddr* /*addr*/, socklen_t* /*addr
 }
 
 int MbedtlsSocket::Accept(int sockfd, sockaddr* addr, socklen_t* addrlen, int flags, const std::string& ca_crt,
-                          const std::string& sever_crt, const std::string& sever_key) {
+                          const std::string& sever_crt, const std::string& sever_key, const bool client_auth) {
   const int connection_fd = sock_->Accept4(sockfd, addr, addrlen, flags);
   if (connection_fd == -1)
     return -1;
@@ -246,7 +246,7 @@ int MbedtlsSocket::Accept(int sockfd, sockaddr* addr, socklen_t* addrlen, int fl
   mbedtls_ssl_conf_rng(&ctx.conf, mbedtls_ctr_drbg_random, &ctr_drbg_);
   mbedtls_ssl_conf_ca_chain(&ctx.conf, &ctx.cacerts, nullptr);
 
-  if (req_client_auth_)
+  if (req_client_auth_ && client_auth)
     mbedtls_ssl_conf_authmode(&ctx.conf, MBEDTLS_SSL_VERIFY_REQUIRED);
 
   CheckResult(mbedtls_ssl_conf_own_cert(&ctx.conf, &ctx.clicert, &ctx.pkey));

--- a/src/mbedtls_test.cc
+++ b/src/mbedtls_test.cc
@@ -126,7 +126,7 @@ TEST(Mbedtls, ServerSendAndRecieveNonBlock) {
   socklen_t len = sizeof(sockaddr);
   int client_fd = -1;
   do {
-    client_fd = sock.Accept(fd, &client_sock, &len, 0, CA_CRT, SERVER_CRT, SERVER_KEY);
+    client_fd = sock.Accept(fd, &client_sock, &len, 0, CA_CRT, SERVER_CRT, SERVER_KEY, true);
   } while (client_fd == -1 && errno == EAGAIN);
 
   EXPECT_GT(client_fd, 0);

--- a/src/mock_socket.h
+++ b/src/mock_socket.h
@@ -62,7 +62,7 @@ struct MockSocket : MbedtlsSocket, RawSocket {
     return client_fd;
   }
 
-  int Accept(int /*sockfd*/, sockaddr* addr, socklen_t* addrlen, int /*flags*/, const std::string& ca_crt, const std::string& client_crt, const std::string& client_key) override {
+  int Accept(int /*sockfd*/, sockaddr* addr, socklen_t* addrlen, int /*flags*/, const std::string& ca_crt, const std::string& client_crt, const std::string& client_key, const bool /*client_auth*/) override {
     // need to return the fd for the accepted connection
     // start from fd = 4 (0-2 are taken by the system and 3 is usually the listening socket)
     int client_fd = static_cast<int>(connections.size() + 4);


### PR DESCRIPTION
best review separately. 

The first commit is needed to be able to distinguish our "external" incoming connections to internal ones in regards to a marblerun cluster. In out usecase this will automatically be set by the marblerun coordinator (see https://github.com/edgelesssys/marblerun/pull/164). The main use is to be able to have external browser connections that usually don't provide a client certificate. 