### PR TITLE
add openssl socket implementation

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -8,6 +8,13 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        cmakeflags:
+        -
+        - -DCMAKE_BUILD_TYPE=Release -DTTLS_ASAN=ON
+        - -DTTLS_OPENSSL=ON
+        - -DCMAKE_BUILD_TYPE=Release -DTTLS_ASAN=ON -DTTLS_OPENSSL=ON
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
@@ -19,22 +26,12 @@ jobs:
           sudo apt install clang-tidy-11 libmbedtls-dev
           mkdir build
 
-      - name: Build Debug
+      - name: Build
         run: |
-          cmake ..
+          cmake ${{ matrix.cmakeflags }} ..
           make -j`nproc`
         working-directory: build
 
-      - name: Test Debug
-        run: ctest --output-on-failure
-        working-directory: build
-
-      - name: Build Release+ASAN
-        run: |
-          cmake -DCMAKE_BUILD_TYPE=Release -DTTLS_ASAN=ON ..
-          make -j`nproc`
-        working-directory: build
-
-      - name: Test Release+ASAN
+      - name: Test
         run: ctest --output-on-failure
         working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,10 +38,16 @@ endif()
 
 add_library(ttlsobj OBJECT
   src/dispatcher.cc
-  src/mbedtls_socket.cc
   src/test_instances.cc
   3rdparty/mbedtls/ssl_server.c
   3rdparty/mbedtls/ssl_client.c)
+
+if(TTLS_OPENSSL)
+  target_compile_definitions(ttlsobj PUBLIC TTLS_OPENSSL)
+  target_sources(ttlsobj PRIVATE src/openssl_socket.cc)
+else()
+  target_sources(ttlsobj PRIVATE src/mbedtls_socket.cc)
+endif()
 
 set_property(TARGET ttlsobj PROPERTY POSITION_INDEPENDENT_CODE ON)
 
@@ -64,7 +70,7 @@ if(NOT TTLS_NOTEST)
     src/util.cc
     src/race_tests.cc)
 
-  target_link_libraries(ttls_test ttls gtest_main mbedtls mbedx509 mbedcrypto)
+  target_link_libraries(ttls_test ttls gtest_main ssl crypto mbedtls mbedx509 mbedcrypto)
 
   include(GoogleTest)
   enable_testing()

--- a/include/ttls/dispatcher.h
+++ b/include/ttls/dispatcher.h
@@ -8,9 +8,9 @@
 #include <string_view>
 #include <unordered_set>
 
-#include "mbedtls_socket.h"
 #include "raw_socket.h"
 #include "socket.h"
+#include "tls_socket.h"
 
 namespace edgeless::ttls {
 
@@ -23,7 +23,7 @@ class Dispatcher final {
    * @param raw Socket functions that will be used if connection should not be wrapped.
    * @param tls Socket functions that will be used if connection should be wrapped.
    */
-  Dispatcher(std::string_view config, RawSockPtr raw, MbedtlsSockPtr tls);
+  Dispatcher(std::string_view config, RawSockPtr raw, TlsSockPtr tls);
 
   ~Dispatcher();
 
@@ -41,7 +41,7 @@ class Dispatcher final {
   const nlohmann::json& Conf() const noexcept;
   bool IsTls(int sockfd);
 
-  //TODO: Refacor to combine mtx and data structure
+  // TODO: Refacor to combine mtx and data structure
 
   std::mutex tls_fds_mtx_;
   std::mutex ip_domain_mtx_;
@@ -54,7 +54,7 @@ class Dispatcher final {
   std::unordered_map<int, std::string> fd_entry_;
   std::unique_ptr<nlohmann::json> config_;
   RawSockPtr raw_;
-  MbedtlsSockPtr tls_;
+  TlsSockPtr tls_;
 };
 
 }  // namespace edgeless::ttls

--- a/include/ttls/openssl_socket.h
+++ b/include/ttls/openssl_socket.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <openssl/ssl.h>
+
+#include <mutex>
+#include <unordered_map>
+
+#include "socket.h"
+
+namespace edgeless::ttls {
+
+class OpensslSocket : public Socket {
+ public:
+  OpensslSocket();
+  OpensslSocket(SocketPtr sock, bool req_client_auth);
+  ~OpensslSocket() override;
+
+  int Close(int sockfd) override;
+  int Connect(int sockfd, const sockaddr* addr, socklen_t addrlen) override;
+  int Accept4(int sockfd, sockaddr* addr, socklen_t* addrlen, int flags) override;
+
+  // accepts a new connection from sockfd and establishes a tls connection on the returned fd
+  virtual int Accept(int sockfd, sockaddr* addr, socklen_t* addrlen, int flags, const std::string& ca_crt,
+                     const std::string& server_crt, const std::string& server_key, bool client_auth);
+  virtual int Connect(int sockfd, const sockaddr* addr, socklen_t addrlen, const std::string& hostname,
+                      const std::string& ca_crt, const std::string& client_crt, const std::string& client_key);
+  ssize_t Recv(int sockfd, void* buf, size_t len, int flags) override;
+  ssize_t Send(int sockfd, const void* buf, size_t len, int flags) override;
+  int Shutdown(int sockfd, int how) override;
+
+ private:
+  static const BIO_METHOD* BioMethod();
+  static int BioRead(BIO* b, char* buf, int len);
+  static int BioWrite(BIO* b, const char* buf, int len);
+  static long BioCtrl(BIO* b, int cmd, long num, void* ptr);  // NOLINT
+  struct Context {
+    SSL_CTX* ssl_ctx{};
+    SSL* ssl{};
+    int fd{-1};
+    SocketPtr sock{};
+    std::mutex mtx;
+  };
+  std::mutex mtx_;
+  std::unordered_map<int, Context> contexts_;
+  SocketPtr sock_;
+
+  bool req_client_auth_;
+};
+
+typedef std::shared_ptr<OpensslSocket> OpensslSockPtr;
+
+}  // namespace edgeless::ttls

--- a/include/ttls/tls_socket.h
+++ b/include/ttls/tls_socket.h
@@ -1,7 +1,22 @@
 #pragma once
 
+#ifdef TTLS_OPENSSL
+
+#include <ttls/openssl_socket.h>
+namespace edgeless::ttls {
+using TlsSocket = OpensslSocket;
+using TlsSockPtr = OpensslSockPtr;
+}  // namespace edgeless::ttls
+#define MBEDTLS_SSL_VERIFY_NONE 0      // NOLINT
+#define MBEDTLS_SSL_VERIFY_REQUIRED 2  // NOLINT
+#define MBEDTLS_NET_LISTEN_BACKLOG 10  // NOLINT
+
+#else
+
 #include <ttls/mbedtls_socket.h>
 namespace edgeless::ttls {
 using TlsSocket = MbedtlsSocket;
 using TlsSockPtr = MbedtlsSockPtr;
 }  // namespace edgeless::ttls
+
+#endif

--- a/include/ttls/tls_socket.h
+++ b/include/ttls/tls_socket.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <ttls/mbedtls_socket.h>
+namespace edgeless::ttls {
+using TlsSocket = MbedtlsSocket;
+using TlsSockPtr = MbedtlsSockPtr;
+}  // namespace edgeless::ttls

--- a/include/ttls/ttls.h
+++ b/include/ttls/ttls.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "dispatcher.h"
-#include "mbedtls_socket.h"
 #include "raw_socket.h"
 #include "socket.h"
 #include "test_instances.h"
+#include "tls_socket.h"

--- a/poc/client-side/client/CMakeLists.txt
+++ b/poc/client-side/client/CMakeLists.txt
@@ -37,4 +37,8 @@ target_include_directories(client
 add_dependencies(client app)
 
 target_link_libraries(plt dl)
-target_link_libraries(client plt ${CMAKE_BINARY_DIR}/app.a ttls Threads::Threads mbedtls mbedx509 mbedcrypto)
+target_link_libraries(client plt ${CMAKE_BINARY_DIR}/app.a ttls Threads::Threads ssl crypto mbedtls mbedx509 mbedcrypto)
+
+if(TTLS_OPENSSL)
+  add_compile_definitions(TTLS_OPENSSL)
+endif()

--- a/poc/client-side/client/main.cc
+++ b/poc/client-side/client/main.cc
@@ -81,7 +81,7 @@ const std::string kCACrt =
 const auto kDispatcherConf = "{\"tls\":{ \"Outgoing\":{\"localhost:9000\": { \"cacrt\": \"" + kCACrt + "\", \"clicrt\": \"\", \"clikey\": \"\" }}}}";
 
 const auto raw = std::make_shared<Sock>();
-const auto tls = std::make_shared<edgeless::ttls::MbedtlsSocket>(raw, false);
+const auto tls = std::make_shared<edgeless::ttls::TlsSocket>(raw, false);
 edgeless::ttls::Dispatcher dis(kDispatcherConf, raw, tls);
 
 int connect_hook(int sockfd, const sockaddr* addr, socklen_t addrlen) {

--- a/poc/server-side/server/CMakeLists.txt
+++ b/poc/server-side/server/CMakeLists.txt
@@ -37,4 +37,8 @@ target_include_directories(server
 add_dependencies(server app)
 
 target_link_libraries(plt dl)
-target_link_libraries(server plt ${CMAKE_BINARY_DIR}/app.a ttls Threads::Threads mbedtls mbedx509 mbedcrypto)
+target_link_libraries(server plt ${CMAKE_BINARY_DIR}/app.a ttls Threads::Threads ssl crypto mbedtls mbedx509 mbedcrypto)
+
+if(TTLS_OPENSSL)
+  add_compile_definitions(TTLS_OPENSSL)
+endif()

--- a/poc/server-side/server/main.cc
+++ b/poc/server-side/server/main.cc
@@ -167,7 +167,7 @@ const std::string kServerKey =
 const auto kDispatcherConf = "{\"tls\":{ \"Outgoing\": {\"localhost:8080\": {\"cacrt\": \"\", \"clicrt\": \"\", \"clikey\": \"\"}}, \"Incoming\": {\"*:9000\": { \"cacrt\": \"" + kCACrt + "\", \"clicrt\": \"" + kServerCert + "\", \"clikey\": \"" + kServerKey + "\", \"clientAuth\": false }}}}";
 
 const auto raw = std::make_shared<Sock>();
-const auto tls = std::make_shared<edgeless::ttls::MbedtlsSocket>(raw, true);
+const auto tls = std::make_shared<edgeless::ttls::TlsSocket>(raw, true);
 edgeless::ttls::Dispatcher dis(kDispatcherConf, raw, tls);
 
 int send_hook(int sockfd, void* buf, size_t len, int flags) {

--- a/src/dispatcher.cc
+++ b/src/dispatcher.cc
@@ -9,8 +9,6 @@
 #include <stdexcept>
 #include <string>
 
-#include "mbedtls_socket.h"
-
 using namespace edgeless::ttls;
 using namespace std::string_literals;
 
@@ -19,7 +17,7 @@ bool Dispatcher::IsTls(int sockfd) {
   return tls_fds_.find(sockfd) != tls_fds_.cend();
 }
 
-Dispatcher::Dispatcher(std::string_view config, RawSockPtr raw, MbedtlsSockPtr tls)
+Dispatcher::Dispatcher(std::string_view config, RawSockPtr raw, TlsSockPtr tls)
     : raw_(std::move(raw)), tls_(std::move(tls)) {
   assert(raw_);
   assert(tls_);
@@ -171,7 +169,7 @@ int Dispatcher::Getaddrinfo(const char* node, const char* service, const addrinf
 
       // save all (IPs, domain) in ip_domain_
       for (const addrinfo* rp = *res; rp != nullptr; rp = rp->ai_next) {
-        //parse ip out of sockaddr
+        // parse ip out of sockaddr
         std::string ip_buf(NI_MAXHOST, ' ');
         ret = getnameinfo(rp->ai_addr, rp->ai_addrlen, ip_buf.data(), NI_MAXHOST, nullptr, 0, NI_NUMERICHOST);
         if (ret != 0) {

--- a/src/mbedtls_test.cc
+++ b/src/mbedtls_test.cc
@@ -3,8 +3,8 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <ttls/libc_socket.h>
-#include <ttls/mbedtls_socket.h>
 #include <ttls/test_instances.h>
+#include <ttls/tls_socket.h>
 
 #include <chrono>
 #include <condition_variable>
@@ -26,7 +26,7 @@ TEST(Mbedtls, Connect) {
   auto t1 = StartTestServer("9000", MBEDTLS_SSL_VERIFY_NONE, credentials.ca_crt, credentials.server_crt, credentials.server_key);
 
   const auto libc_sock = std::make_shared<LibcSocket>();
-  MbedtlsSocket sock(libc_sock, true);
+  TlsSocket sock(libc_sock, true);
   sockaddr sock_addr = MakeSockaddr("127.0.0.1", 9000);
   EXPECT_EQ(sock.Connect(fd, &sock_addr, sizeof(sock_addr), "", credentials.ca_crt, "", ""), 0);
   EXPECT_EQ(0, sock.Shutdown(fd, SHUT_RDWR));
@@ -43,7 +43,7 @@ TEST(Mbedtls, ConnectNonBlock) {
   auto t1 = StartTestServer("9000", MBEDTLS_SSL_VERIFY_NONE, credentials.ca_crt, credentials.server_crt, credentials.server_key);
 
   const auto libc_sock = std::make_shared<LibcSocket>();
-  MbedtlsSocket sock(libc_sock, true);
+  TlsSocket sock(libc_sock, true);
   sockaddr sock_addr = MakeSockaddr("127.0.0.1", 9000);
   EXPECT_EQ(sock.Connect(fd, &sock_addr, sizeof(sock_addr), "", credentials.ca_crt, "", ""), 0);
   EXPECT_EQ(0, sock.Shutdown(fd, 2));
@@ -60,7 +60,7 @@ TEST(Mbedtls, SendAndRecieve) {
   auto t1 = StartTestServer("9000", MBEDTLS_SSL_VERIFY_NONE, credentials.ca_crt, credentials.server_crt, credentials.server_key);
 
   const auto libc_sock = std::make_shared<LibcSocket>();
-  MbedtlsSocket sock(libc_sock, true);
+  TlsSocket sock(libc_sock, true);
   sockaddr sock_addr = MakeSockaddr("127.0.0.1", 9000);
   EXPECT_EQ(sock.Connect(fd, &sock_addr, sizeof(sock_addr), "", credentials.ca_crt, "", ""), 0);
   EXPECT_EQ(sock.Send(fd, kRequest.data(), kRequest.size(), 0), kRequest.size());
@@ -82,7 +82,7 @@ TEST(Mbedtls, SendAndRecieveNonBlock) {
   auto t1 = StartTestServer("9000", MBEDTLS_SSL_VERIFY_NONE, credentials.ca_crt, credentials.server_crt, credentials.server_key);
 
   const auto libc_sock = std::make_shared<LibcSocket>();
-  MbedtlsSocket sock(libc_sock, true);
+  TlsSocket sock(libc_sock, true);
   sockaddr sock_addr = MakeSockaddr("127.0.0.1", 9000);
   EXPECT_EQ(sock.Connect(fd, &sock_addr, sizeof(sock_addr), "", credentials.ca_crt, "", ""), 0);
   EXPECT_EQ(sock.Send(fd, kRequest.data(), kRequest.size(), 0), kRequest.size());
@@ -113,7 +113,7 @@ TEST(Mbedtls, ConnectClientAuth) {
   auto t1 = StartTestServer("9000", MBEDTLS_SSL_VERIFY_REQUIRED, credentials.ca_crt, credentials.server_crt, credentials.server_key);
 
   const auto libc_sock = std::make_shared<LibcSocket>();
-  MbedtlsSocket sock(libc_sock, true);
+  TlsSocket sock(libc_sock, true);
   sockaddr sock_addr = MakeSockaddr("127.0.0.1", 9000);
   EXPECT_EQ(sock.Connect(fd, &sock_addr, sizeof(sock_addr), "", credentials.ca_crt, credentials.cli_crt, credentials.cli_key), 0);
   EXPECT_EQ(0, sock.Shutdown(fd, SHUT_RDWR));
@@ -128,7 +128,7 @@ TEST(Mbedtls, ServerSendAndRecieveNonBlock) {
   TestCredentials credentials;
 
   const auto libc_sock = std::make_shared<LibcSocket>();
-  MbedtlsSocket sock(libc_sock, true);
+  TlsSocket sock(libc_sock, true);
   sockaddr sock_addr = MakeSockaddr("127.0.0.1", 9010);
   ASSERT_EQ(bind(fd, &sock_addr, sizeof(sockaddr)), 0);
   ASSERT_EQ(listen(fd, MBEDTLS_NET_LISTEN_BACKLOG), 0);

--- a/src/mock_socket.h
+++ b/src/mock_socket.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ttls/mbedtls_socket.h>
+#include <ttls/tls_socket.h>
 
 #include <algorithm>
 #include <array>
@@ -22,7 +22,7 @@ struct Connection {
   std::vector<char> msg_buf{};
 };
 
-struct MockSocket : MbedtlsSocket, RawSocket {
+struct MockSocket : TlsSocket, RawSocket {
   std::unordered_map<int, Connection> connections;
 
   int Close(int fd) override {

--- a/src/openssl_socket.cc
+++ b/src/openssl_socket.cc
@@ -1,0 +1,322 @@
+#include "openssl_socket.h"
+
+#include <openssl/err.h>
+#include <poll.h>
+
+#include <array>
+#include <cassert>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+using namespace edgeless::ttls;
+using BioPtr = std::unique_ptr<BIO, decltype(&BIO_free)>;
+using X509Ptr = std::unique_ptr<X509, decltype(&X509_free)>;
+using PkeyPtr = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>;
+
+static int CheckResult(const SSL* ssl, const int ret, const int default_errno = EPROTO) {
+  using namespace std::string_literals;
+  if (ret > 0) {
+    return ret;
+  }
+  switch (SSL_get_error(ssl, ret)) {
+    case SSL_ERROR_ZERO_RETURN:
+      return 0;
+    case SSL_ERROR_WANT_READ:
+    case SSL_ERROR_WANT_WRITE:
+      throw std::system_error(EAGAIN, std::generic_category(), "openssl: want read/write");
+    case SSL_ERROR_SYSCALL:
+      throw std::system_error(errno ? errno : default_errno, std::generic_category(), "openssl: syscall");
+  }
+
+  std::array<char, 256> buf{};
+  ERR_error_string_n(ERR_get_error(), buf.data(), buf.size());
+  throw std::system_error(default_errno, std::generic_category(), "openssl: "s + buf.data());
+}
+
+static void AddCaCerts(const SSL_CTX* ctx, const std::string& ca_pem) {
+  const BioPtr bio(BIO_new_mem_buf(ca_pem.data(), static_cast<int>(ca_pem.size())), BIO_free);
+  if (!bio)
+    throw std::runtime_error("openssl: cannot create CA BIO");
+  const X509Ptr cert(PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr), X509_free);
+  if (!cert)
+    throw std::runtime_error("openssl: cannot parse CA certificate");
+  if (X509_STORE_add_cert(SSL_CTX_get_cert_store(ctx), cert.get()) != 1)
+    throw std::runtime_error("openssl: cannot add CA certificate");
+}
+
+static void LoadCertificate(SSL_CTX* ctx, const std::string& cert_pem) {
+  const BioPtr bio(BIO_new_mem_buf(cert_pem.data(), static_cast<int>(cert_pem.size())), BIO_free);
+  if (!bio)
+    throw std::runtime_error("openssl: cannot create certificate BIO");
+  const X509Ptr cert(PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr), X509_free);
+  if (!cert)
+    throw std::runtime_error("openssl: cannot parse certificate");
+  if (SSL_CTX_use_certificate(ctx, cert.get()) != 1)
+    throw std::runtime_error("openssl: cannot load certificate");
+}
+
+static void LoadPrivateKey(SSL_CTX* ctx, const std::string& key_pem) {
+  const BioPtr bio(BIO_new_mem_buf(key_pem.data(), static_cast<int>(key_pem.size())), BIO_free);
+  if (!bio)
+    throw std::runtime_error("openssl: cannot create key BIO");
+  const PkeyPtr key(PEM_read_bio_PrivateKey(bio.get(), nullptr, nullptr, nullptr), EVP_PKEY_free);
+  if (!key)
+    throw std::runtime_error("openssl: cannot parse private key");
+  if (SSL_CTX_use_PrivateKey(ctx, key.get()) != 1)
+    throw std::runtime_error("openssl: cannot load private key");
+  if (SSL_CTX_check_private_key(ctx) != 1)
+    throw std::runtime_error("openssl: private key does not match certificate");
+}
+
+OpensslSocket::OpensslSocket()
+    : req_client_auth_(false) {
+}
+
+OpensslSocket::OpensslSocket(SocketPtr sock, bool req_client_auth)
+    : sock_(std::move(sock)), req_client_auth_(req_client_auth) {
+  assert(sock_);
+}
+
+OpensslSocket::~OpensslSocket() = default;
+
+const BIO_METHOD* OpensslSocket::BioMethod() {
+  static const BIO_METHOD* method = [] {
+    BIO_METHOD* const m = BIO_meth_new(BIO_TYPE_NONE, "ttls");
+    if (!m)
+      throw std::runtime_error("openssl: cannot create BIO method");
+    BIO_meth_set_read(m, BioRead);
+    BIO_meth_set_write(m, BioWrite);
+    BIO_meth_set_ctrl(m, BioCtrl);
+    return m;
+  }();
+  return method;
+}
+
+int OpensslSocket::BioRead(BIO* b, char* buf, int len) {
+  BIO_clear_retry_flags(b);
+  const auto& context = *static_cast<Context*>(BIO_get_data(b));
+  if (context.fd < 0)
+    return 0;
+  const auto ret = context.sock->Recv(context.fd, buf, static_cast<size_t>(len), 0);
+  if (ret >= 0)
+    return static_cast<int>(ret);
+  switch (errno) {
+    case EAGAIN:
+    case EINTR:
+      BIO_set_retry_read(b);
+      return -1;
+    default:
+      return -1;
+  }
+}
+
+int OpensslSocket::BioWrite(BIO* b, const char* buf, int len) {
+  BIO_clear_retry_flags(b);
+  const auto& context = *static_cast<Context*>(BIO_get_data(b));
+  if (context.fd < 0)
+    return 0;
+  const auto ret = context.sock->Send(context.fd, buf, static_cast<size_t>(len), 0);
+  if (ret >= 0)
+    return ret;
+  switch (errno) {
+    case EAGAIN:
+    case EINTR:
+      BIO_set_retry_write(b);
+      return -1;
+    default:
+      return -1;
+  }
+}
+
+long OpensslSocket::BioCtrl(BIO* /*b*/, int cmd, long /*num*/, void* /*ptr*/) {  // NOLINT
+  return cmd == BIO_CTRL_FLUSH ? 1 : 0;
+}
+
+/**
+ * Close fd and clean up context
+ */
+int OpensslSocket::Close(int sockfd) {
+  std::lock_guard<std::mutex> lock(mtx_);
+  auto& ctx = contexts_.at(sockfd);
+
+  SSL_free(ctx.ssl);
+  SSL_CTX_free(ctx.ssl_ctx);
+
+  if (sock_->Close(ctx.fd) != 0) {
+    throw std::runtime_error("close failed");
+  }
+  contexts_.erase(sockfd);
+  return 0;
+}
+
+/*
+ * Gracefully shutdown TLS and TCP connection
+ */
+int OpensslSocket::Shutdown(int sockfd, int how) {
+  std::lock_guard<std::mutex> lock(mtx_);
+  auto& ctx = contexts_.at(sockfd);
+
+  if (SSL_shutdown(ctx.ssl) < 0 || sock_->Shutdown(ctx.fd, how) != 0) {
+    throw std::runtime_error("shutdown failed");
+  }
+  return 0;
+}
+
+int OpensslSocket::Connect(int /*sockfd*/, const sockaddr* /*addr*/, socklen_t /*addrlen*/) {
+  throw std::runtime_error("no crt provided");
+}
+
+int OpensslSocket::Connect(int sockfd, const sockaddr* addr, socklen_t addrlen, const std::string& hostname, const std::string& ca_crt,
+                           const std::string& client_crt, const std::string& client_key) {
+  const auto ret = [&] {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return contexts_.try_emplace(sockfd);
+  }();
+
+  if (!ret.second)
+    throw std::system_error(EISCONN, std::system_category(), __func__);
+  auto& ctx = ret.first->second;
+
+  ctx.sock = sock_;
+  ctx.fd = sockfd;
+
+  ctx.ssl_ctx = SSL_CTX_new(TLS_client_method());
+  if (!ctx.ssl_ctx)
+    throw std::runtime_error("openssl: cannot create client context");
+
+  SSL_CTX_set_verify(ctx.ssl_ctx, SSL_VERIFY_PEER, nullptr);
+  AddCaCerts(ctx.ssl_ctx, ca_crt);
+
+  // Client Auth
+  if (!client_crt.empty() && !client_key.empty()) {
+    LoadCertificate(ctx.ssl_ctx, client_crt);
+    LoadPrivateKey(ctx.ssl_ctx, client_key);
+  }
+
+  ctx.ssl = SSL_new(ctx.ssl_ctx);
+  if (!ctx.ssl)
+    throw std::runtime_error("openssl: cannot create ssl handle");
+
+  if (!hostname.empty() && !SSL_set1_host(ctx.ssl, hostname.c_str()))
+    throw std::runtime_error("openssl: cannot set hostname for verification");
+
+  BIO* const bio = BIO_new(BioMethod());
+  if (!bio)
+    throw std::runtime_error("openssl: cannot create BIO");
+  BIO_set_data(bio, &ctx);
+  SSL_set_bio(ctx.ssl, bio, bio);
+
+  if (sock_->Connect(sockfd, addr, addrlen) && errno != EINPROGRESS) {
+    throw std::system_error(errno, std::generic_category());
+  }
+
+  pollfd pfd{ctx.fd, POLLOUT | POLLIN, 0};
+  int re = -1;
+  do {
+    if (poll(&pfd, 1, -1) < 0)
+      throw std::runtime_error("socket unavailable");
+
+    ERR_clear_error();
+    re = SSL_connect(ctx.ssl);
+    if (re == 1)
+      break;
+    const int err = SSL_get_error(ctx.ssl, re);
+    if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+      continue;
+    }
+
+    this->Shutdown(ctx.fd, SHUT_RDWR);
+    CheckResult(ctx.ssl, re, ECONNREFUSED);
+  } while (true);
+
+  return 0;
+}
+
+ssize_t OpensslSocket::Recv(int sockfd, void* buf, size_t len, int /*flags*/) {
+  auto& ctx = [&]() -> auto& {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return contexts_.at(sockfd);
+  }();
+  const std::lock_guard lock(ctx.mtx);
+  ERR_clear_error();
+  return CheckResult(ctx.ssl, SSL_read(ctx.ssl, buf, static_cast<int>(len)));
+}
+
+ssize_t OpensslSocket::Send(int sockfd, const void* buf, size_t len, int /*flags*/) {
+  auto& ctx = [&]() -> auto& {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return contexts_.at(sockfd);
+  }();
+  const std::lock_guard lock(ctx.mtx);
+  ERR_clear_error();
+  return CheckResult(ctx.ssl, SSL_write(ctx.ssl, buf, static_cast<int>(len)));
+}
+
+int OpensslSocket::Accept4(int /*sockfd*/, sockaddr* /*addr*/, socklen_t* /*addrlen*/, int /*flags*/) {
+  throw std::runtime_error("no crt provided");
+}
+
+int OpensslSocket::Accept(int sockfd, sockaddr* addr, socklen_t* addrlen, int flags, const std::string& ca_crt,
+                          const std::string& server_crt, const std::string& server_key, const bool client_auth) {
+  const int connection_fd = sock_->Accept4(sockfd, addr, addrlen, flags);
+  if (connection_fd == -1)
+    throw std::system_error(errno, std::generic_category());
+  const auto ret = [&] {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return contexts_.try_emplace(connection_fd);
+  }();
+
+  if (!ret.second)
+    throw std::system_error(EISCONN, std::system_category(), __func__);
+  auto& ctx = ret.first->second;
+  ctx.sock = sock_;
+  ctx.fd = connection_fd;
+
+  ctx.ssl_ctx = SSL_CTX_new(TLS_server_method());
+  if (!ctx.ssl_ctx)
+    throw std::runtime_error("openssl: cannot create server context");
+
+  AddCaCerts(ctx.ssl_ctx, ca_crt);
+
+  if (req_client_auth_ && client_auth)
+    SSL_CTX_set_verify(ctx.ssl_ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
+
+  LoadCertificate(ctx.ssl_ctx, server_crt);
+  LoadPrivateKey(ctx.ssl_ctx, server_key);
+
+  ctx.ssl = SSL_new(ctx.ssl_ctx);
+  if (!ctx.ssl)
+    throw std::runtime_error("openssl: cannot create ssl handle");
+
+  BIO* const bio = BIO_new(BioMethod());
+  if (!bio)
+    throw std::runtime_error("openssl: cannot create BIO");
+  BIO_set_data(bio, &ctx);
+  SSL_set_bio(ctx.ssl, bio, bio);
+
+  pollfd pfd{ctx.fd, POLLOUT | POLLIN, 0};
+  int re = -1;
+  do {
+    if (poll(&pfd, 1, -1) < 0)
+      throw std::runtime_error("socket unavailable");
+
+    ERR_clear_error();
+    re = SSL_accept(ctx.ssl);
+    if (re == 1)
+      break;
+    const int err = SSL_get_error(ctx.ssl, re);
+    if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+      continue;
+    }
+
+    try {
+      CheckResult(ctx.ssl, re, ECONNABORTED);
+    } catch (...) {
+      this->Close(ctx.fd);
+      throw;
+    }
+  } while (true);
+
+  return ctx.fd;
+}

--- a/src/race_tests.cc
+++ b/src/race_tests.cc
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 #include <ttls/dispatcher.h>
 #include <ttls/libc_socket.h>
-#include <ttls/mbedtls_socket.h>
 #include <ttls/test_instances.h>
+#include <ttls/tls_socket.h>
 
 #include <thread>
 
@@ -12,7 +12,7 @@ using namespace edgeless::ttls;
 
 TEST(Race, Client) {
   const auto raw = std::make_shared<LibcSocket>();
-  const auto tls = std::make_shared<MbedtlsSocket>(raw, false);
+  const auto tls = std::make_shared<TlsSocket>(raw, false);
 
   TestCredentials credentials;
   const std::string ca_crt_encoded = JSONescape(credentials.ca_crt);
@@ -98,7 +98,7 @@ TEST(Race, Client) {
 
 TEST(Race, Server) {
   const auto raw = std::make_shared<LibcSocket>();
-  const auto tls = std::make_shared<MbedtlsSocket>(raw, false);
+  const auto tls = std::make_shared<TlsSocket>(raw, false);
 
   TestCredentials credentials;
   const std::string ca_crt_encoded = JSONescape(credentials.ca_crt);


### PR DESCRIPTION
Previously, mbedtls was used to wrap connections in TLS. This adds an `OpensslSocket` implementation in addition to the existing `MbedtlsSocket`. It can be chosen at compile time with `cmake -DTTLS_OPENSSL=ON`.